### PR TITLE
sources.json: upgrade to nixos-21.05 branch

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -44,7 +44,7 @@ in rec {
   # a custom version of cachix which won't output status messages to stdout, which
   # would get in the way of our use of the stdout to read build outputs
   cachix_stderr = pkgs.cachix.overrideAttrs (oldAttrs: {
-    patchPhase = oldAttrs.patchPhase + ''
+    patchPhase = (if oldAttrs ? patchPhase then oldAttrs.patchPhase else "") + ''
       find ./ -type f -exec sed -i \
         -e 's|\bputText\b|putErrText|g' \
         -e 's|\bputStr\b|hPutStr stderr|g' \

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,14 +1,14 @@
 {
     "nixpkgs": {
-        "branch": "nixos-20.09",
+        "branch": "nixos-21.05",
         "description": "Nix Packages collection",
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "85ed11208f8c7c981071cc6e33a5fc60c396c38f",
-        "sha256": "0kq0rg6yyfr2pdyn0dmsmls0mdf3v5x0msjisj9v9pmb6k6jr39j",
+        "rev": "c06613c25df3fe1dd26243847a3c105cf6770627",
+        "sha256": "16si1436wf3fcx91p6cy3qxaib8kr78qivbi69lq4m63n96gglkv",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/85ed11208f8c7c981071cc6e33a5fc60c396c38f.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/c06613c25df3fe1dd26243847a3c105cf6770627.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/tests/images.nix
+++ b/tests/images.nix
@@ -23,7 +23,7 @@ rec {
   alpine-fetched = pkgs.dockerTools.pullImage {
     imageName = "alpine";
     imageDigest = "sha256:4661fb57f7890b9145907a1fe2555091d333ff3d28db86c3bb906f6a2be93c87";
-    sha256 = "1bgva9np37zmijgbk0lvw7ywfv7zkxqsi1dm7m4i6n5pj8l51afg";
+    sha256 = "053ja4s6bqamjs758x2yrzxym00qjq4c4ij2cdz0xxgqd7h06ijw";
     os = "linux";
     arch = "x86_64";
   };


### PR DESCRIPTION
New stable branch.

New `dockerTools` clearly changed the content hash of the pulled/extracted alpine image.