### PR TITLE
upgrade to nixos 21.11 branch

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -84,7 +84,7 @@ jobs:
                 # using but not pushing to cache from stage-0
                 $CACHIX use ((cachix-cache))
 
-                nix-channel --add https://nixos.org/channels/nixos-20.09 nixpkgs
+                nix-channel --add https://nixos.org/channels/nixos-21.11 nixpkgs
                 nix-channel --update
                 SKOPEO=$(nix-build '<nixpkgs>' -A skopeo)/bin/skopeo
                 OCI_IMAGE_TOOL=$(nix-build '<nixpkgs>' -A oci-image-tool)/bin/oci-image-tool

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -66,6 +66,7 @@ jobs:
             type: registry-image
             source:
               repository: nixos/nix
+              tag: sha256:1e19753e8150c11afb8327d47595e41707c23cb36907539bb48cfa703821a2a8
           inputs:
             - name: nix-build-task-git
           outputs:

--- a/default.nix
+++ b/default.nix
@@ -8,8 +8,8 @@ let
   # TODO use a lighter-weight base image
   baseImage_ = if baseImage != null then baseImage else pkgs.dockerTools.pullImage {
     imageName = "nixos/nix";
-    imageDigest = "sha256:a6bcef50c7ca82ca66965935a848c8c388beb78c9a5de3e3b3d4ea298c95c708";
-    sha256 = "0a5zbxvr7ls0s9f1alp8sf0df0cripqcs0x71ldqdpal9hvqwif1";
+    imageDigest = "sha256:1e19753e8150c11afb8327d47595e41707c23cb36907539bb48cfa703821a2a8";
+    sha256 = "054y3m1fwv1iiqckx17s7ldd1av6crmwypsmvjnqhy8vv0mic0gd";
     os = "linux";
     arch = "x86_64";
   };

--- a/default.nix
+++ b/default.nix
@@ -23,7 +23,7 @@ in rec {
     contents = pkgs.runCommand "build" {
       buildInputs = [ pkgs.python3 pkgs.makeWrapper ];
       wrappedPath = pkgs.lib.makeBinPath (with pkgs; [
-        cachix_stderr
+        cachix
         gnutar
         gzip
         nix
@@ -41,16 +41,6 @@ in rec {
 
     config.Cmd = [ "/bin/build" ];
   };
-  # a custom version of cachix which won't output status messages to stdout, which
-  # would get in the way of our use of the stdout to read build outputs
-  cachix_stderr = pkgs.cachix.overrideAttrs (oldAttrs: {
-    patchPhase = (if oldAttrs ? patchPhase then oldAttrs.patchPhase else "") + ''
-      find ./ -type f -exec sed -i \
-        -e 's|\bputText\b|putErrText|g' \
-        -e 's|\bputStr\b|hPutStr stderr|g' \
-        {} \;
-    '';
-  });
   bumpSources = pkgs.writeScript "bump-sources" ''
     #!${pkgs.bash}/bin/bash
     set -e

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,14 +1,14 @@
 {
     "nixpkgs": {
-        "branch": "nixos-21.05",
+        "branch": "nixos-21.11",
         "description": "Nix Packages collection",
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "43cdc5b364511eabdcad9fde639777ffd9e5bab1",
-        "sha256": "1wrd5rrpa2fcy6q9193vgihiqmqc686vmwqyn24cb0fk1a37m2g4",
+        "rev": "00f84d37a2507dee0219cf894f11a7cbf0c49ccb",
+        "sha256": "1vn0y9rppsw5bvn0mrhfd1vgx7kqcdaw6j9x1623qbj27rz3aj7i",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/43cdc5b364511eabdcad9fde639777ffd9e5bab1.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/00f84d37a2507dee0219cf894f11a7cbf0c49ccb.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
Also pinning bootstrap image to the last (?) old alpine-based one as it looks like we're not quite ready for the slimmer pure-nix ones.

Bump default `baseImage` to the same.