### PR TITLE
switch to umoci for image unpacking. bump sources to nixos-22.05 branch

### DIFF
--- a/build.py
+++ b/build.py
@@ -219,12 +219,12 @@ def _image_unpack(image_type, image_tar_path):
         rootfs_path = image_tar_path.parent / "rootfs"
         subprocess.run(
             (
-                "oci-image-tool",
+                "umoci",
+                "raw",
                 "unpack",
+                "--image",
                 td,
                 rootfs_path,
-                "--ref",
-                "name=latest",
             ),
             check=True,
         )

--- a/default.nix
+++ b/default.nix
@@ -14,6 +14,7 @@ let
     arch = "x86_64";
   };
 in rec {
+  inherit (pkgs) niv;
   image = pkgs.dockerTools.buildImage {
     name = "nix-build-task";
     tag = "latest";
@@ -27,7 +28,7 @@ in rec {
         gnutar
         gzip
         nix
-        oci-image-tool
+        umoci
         skopeo
         xz
       ]);

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,14 +1,14 @@
 {
     "nixpkgs": {
-        "branch": "nixos-21.11",
+        "branch": "nixos-22.05",
         "description": "Nix Packages collection",
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a7f0b0832f9da86d25089ea2b4cacdea64072d7f",
-        "sha256": "1zcqji4bidf3ykbpk0qlq86kzg1fimivzciv3lxwvmkfkdpa68r2",
+        "rev": "dbb62c34bbb5cdf05f1aeab07638b24b0824d605",
+        "sha256": "0v9c7j1ay2wk01mcfbc621f5n11bvl26018k3bc3h8wdssppm9ra",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/a7f0b0832f9da86d25089ea2b4cacdea64072d7f.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/dbb62c34bbb5cdf05f1aeab07638b24b0824d605.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -31,8 +31,28 @@ let
           if spec ? branch then "refs/heads/${spec.branch}" else
             if spec ? tag then "refs/tags/${spec.tag}" else
               abort "In git source '${name}': Please specify `ref`, `tag` or `branch`!";
+      submodules = if spec ? submodules then spec.submodules else false;
+      submoduleArg =
+        let
+          nixSupportsSubmodules = builtins.compareVersions builtins.nixVersion "2.4" >= 0;
+          emptyArgWithWarning =
+            if submodules == true
+            then
+              builtins.trace
+                (
+                  "The niv input \"${name}\" uses submodules "
+                  + "but your nix's (${builtins.nixVersion}) builtins.fetchGit "
+                  + "does not support them"
+                )
+                {}
+            else {};
+        in
+          if nixSupportsSubmodules
+          then { inherit submodules; }
+          else emptyArgWithWarning;
     in
-      builtins.fetchGit { url = spec.repo; inherit (spec) rev; inherit ref; };
+      builtins.fetchGit
+        ({ url = spec.repo; inherit (spec) rev; inherit ref; } // submoduleArg);
 
   fetch_local = spec: spec.path;
 


### PR DESCRIPTION
`oci-image-tool` has been removed from nixpkgs in 22.05: https://github.com/NixOS/nixpkgs/pull/172995

Fortunately `umoci` can now fill the gap we needed it for.

Bump sources to nixpkgs 22.05 in celebration.