### PR TITLE
nixpkgs: nixos-22.05 -> nixos-22.11

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -81,8 +81,11 @@ jobs:
               - |
                 CACHIX=$(nix-build '<nixpkgs>' -A cachix)/bin/cachix
 
-                # using but not pushing to cache from stage-0
-                $CACHIX use ((cachix-cache))
+                # TODO re-enable cachix use in bootstrap once we're using a
+                # more modern image to bootstrap from (with a zstd-supporting
+                # nix)
+                ## using but not pushing to cache from stage-0
+                #$CACHIX use ((cachix-cache))
 
                 nix-channel --add https://nixos.org/channels/nixos-21.11 nixpkgs
                 nix-channel --update
@@ -112,8 +115,11 @@ jobs:
             NIXFILE: nix-build-task-git
             ATTR0: image
             OUTPUT0_PREPARE_IMAGE: 1
-            CACHIX_CACHE: ((cachix-cache))
-            CACHIX_SIGNING_KEY: ((cachix-signing-key))
+            # TODO re-enable cachix use in bootstrap once we're using a
+            # more modern image to bootstrap from (with a zstd-supporting
+            # nix)
+            #CACHIX_CACHE: ((cachix-cache))
+            #CACHIX_SIGNING_KEY: ((cachix-signing-key))
           run:
             path: /bin/build
 

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,14 +1,14 @@
 {
     "nixpkgs": {
-        "branch": "nixos-22.05",
+        "branch": "nixos-22.11",
         "description": "Nix Packages collection",
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0faaf0a9bb6dedb69bfd43ac06fb27fadc476c51",
-        "sha256": "1jxrhxvrq3vflalgcxybiny8y8ikdcf75i1cs7ajkq80vlybhvwy",
+        "rev": "0bf3109eeb61780965c27f4a0a4affdcd0cd4d3d",
+        "sha256": "17bk7s5908bc21mvh31ra94pdqmr2pdrlhavqga6ysfl013jnpvv",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/0faaf0a9bb6dedb69bfd43ac06fb27fadc476c51.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/0bf3109eeb61780965c27f4a0a4affdcd0cd4d3d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
New cachix pushes zstd-compressed NARs, which the old base image we're bootstrapping from doesn't support. Skip cachix use in bootstrap (perhaps we should always do this?).

Waiting on https://github.com/NixOS/nixpkgs/pull/208944 to switch to a "modern" nix docker base & bootstrap image.