### PR TITLE
nixpkgs: 22.11 -> 23.05

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -393,51 +393,36 @@ jobs:
                   bunzip2 -c $f >> all_logs
                 done
                 egrep 'Building something slightly random' all_logs
-      - try:
-          task: build-non-deterministic-enforce-option
-          image: nix-build-task-staging-dockerhub
-          config:
-            platform: linux
-            inputs:
-              - name: nix-build-task-git
-            outputs:
-              - name: non-deterministic-output
-                path: output
-            params:
-              NIXFILE: nix-build-task-git/tests/other.nix
-              ATTR: deliberatelyNonDeterministic
-              NIX_OPTION_enforce-determinism: true
-              NIX_OPTION_repeat: 2
-            run:
-              path: /bin/build
-          on_failure:
-            task: record-determinism-failure
-            image: busybox-image
-            config:
-              platform: linux
-              outputs:
-                - name: non-deterministic-output
-              run:
-                path: /bin/ash
-                args:
-                  - -e
-                  - -c
-                  - |
-                    touch non-deterministic-output/failure-recorded
-      - task: check-determinism-failure
+      - task: build-alt-system-option
+        image: nix-build-task-staging-dockerhub
+        config:
+          platform: linux
+          inputs:
+            - name: nix-build-task-git
+          outputs:
+            - name: alt-system-output
+              path: output
+          params:
+            NIXFILE: nix-build-task-git/tests/other.nix
+            ATTR: bash
+            NIX_OPTION_system: i686-linux
+          run:
+            path: /bin/build
+      - task: check-output-arch
         image: busybox-image
         config:
           platform: linux
           inputs:
-            - name: non-deterministic-output
+            - name: alt-system-output
           run:
             path: /bin/ash
             args:
               - -e
               - -c
               - |
-                if ! [ -e non-deterministic-output/failure-recorded ] ; then
-                  echo "Expected non-deterministic-output/failure-recorded to have been created by record-determinism-failure"
+                ELF_CLASS_BYTE="$(hexdump -e '"0x%02x"' -n 1 -s 4 < alt-system-output/result/bin/bash)"
+                if [ "$ELF_CLASS_BYTE" != '0x01' ] ; then
+                  echo "Expected output binary's ELF_CLASS_BYTE to be 0x01 (32-bit) but was $ELF_CLASS_BYTE"
                   exit 7
                 fi
       - task: build-with-nar-export

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,14 +1,14 @@
 {
     "nixpkgs": {
-        "branch": "nixos-22.11",
+        "branch": "nixos-23.05",
         "description": "Nix Packages collection",
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "824f886682fc893e6dbf27114e5001ebf2770ea1",
-        "sha256": "0yr8c69zn9bqbfz4zld880sm3fycrdyz5h2dc3xh8pf08lvhl3nx",
+        "rev": "4c8cf44c5b9481a4f093f1df3b8b7ba997a7c760",
+        "sha256": "1fq4k8b4jxzwsydwg0sf4yg00qfdqaf1fgv3ya9l5923hwv2klp6",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/824f886682fc893e6dbf27114e5001ebf2770ea1.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/4c8cf44c5b9481a4f093f1df3b8b7ba997a7c760.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/tests/other.nix
+++ b/tests/other.nix
@@ -32,6 +32,7 @@ in rec {
     ] ++ pkgs.lib.optional includeTarball {name = "linux_1_0.tar.gz"; path = linux_1_0;}
   );
   skopeo = pkgs.skopeo;
+  bash = pkgs.bash;
   deliberatelyNonDeterministicBTD = mkNonDeterministicDrv "${someArg}-btd" "" "";
   deliberatelyNonDeterministicRTD = mkNonDeterministicDrv "${someArg}-rtd" "" "";
   deliberatelyNonDeterministic = mkNonDeterministicDrv someArg deliberatelyNonDeterministicRTD deliberatelyNonDeterministicBTD;


### PR DESCRIPTION
New nix requires a small pipeline change as one of the features we were (ab)using in tests has been removed.